### PR TITLE
Use official endpoints for discovering latest Swift releases

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
          #arch: ['x86_64']
          # build both the quick (x86_64) and complete (aarch64,x86_64,armv7) SDKs
          #arch: ['x86_64', '']
-         swift-version: ['release', 'devel', 'trunk']
+         swift-version: ['release', 'swift-6.2-branch', 'development']
      runs-on: ubuntu-24.04
      steps:
       - name: Free Disk Space
@@ -52,7 +52,7 @@ jobs:
         run: |
           # these variabes are used by build-docker and build-local
           # to determine which Swift version to build for
-          echo "BUILD_VERSION=${{ matrix.swift-version }}" >> $GITHUB_ENV
+          echo "BUILD_SCHEME=${{ matrix.swift-version }}" >> $GITHUB_ENV
           echo "TARGET_ARCHS=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "WORKDIR=${{ runner.temp }}/swift-android-sdk" >> $GITHUB_ENV
       - name: Checkout repository
@@ -62,12 +62,12 @@ jobs:
         working-directory: swift-ci/sdks/android
         run: |
           sudo apt install -q ninja-build patchelf
-          ./build-local ${BUILD_VERSION} ${WORKDIR}
+          ./build-local ${BUILD_SCHEME} ${WORKDIR}
       - name: Build Android SDK (Docker)
         if: ${{ matrix.build-type == 'docker' }}
         working-directory: swift-ci/sdks/android
         run: |
-          ./build-docker ${BUILD_VERSION} ${WORKDIR}
+          ./build-docker ${BUILD_SCHEME} ${WORKDIR}
       - name: Install Host Toolchain
         if: ${{ matrix.build-type == 'docker' }}
         working-directory: swift-ci/sdks/android

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,16 +22,6 @@ jobs:
           path: |
             *.log
 
-   static-linux-build:
-     name: Build Static Linux image
-     runs-on: ubuntu-latest
-     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Build Docker images
-        working-directory: swift-ci/sdks/static-linux
-        run: ./build
-
    android-build:
      name: Build Android ${{ matrix.build-type }} ${{ matrix.swift-version }} ${{ matrix.arch }} SDK
      strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .*.swp
-static-swift-linux-sources

--- a/swift-ci/sdks/android/README.md
+++ b/swift-ci/sdks/android/README.md
@@ -25,11 +25,15 @@ Android NDK that will be used for cross-compilation.
 
 The `version` argument can be one of the following values:
 
-| version | Swift version |
+| version | Swift version example |
 | --- | --- |
 | `release` | swift-6.1-RELEASE |
-| `devel` | swift-6.2-DEVELOPMENT-SNAPSHOT-yyyy-mm-dd |
-| `trunk` | swift-DEVELOPMENT-SNAPSHOT-yyyy-mm-dd |
+| `swift-6.2-branch` | swift-6.2-DEVELOPMENT-SNAPSHOT-yyyy-mm-dd |
+| `development` | swift-DEVELOPMENT-SNAPSHOT-yyyy-mm-dd |
+
+> [!WARNING]
+> The workdir argument must not be located in a git repository (e.g., it cannot be the
+> current directory)
 
 ## Running
 
@@ -52,12 +56,11 @@ up the build. This can be useful, e.g., as part of a CI that
 validates a pull request, as building a single architecture
 takes around 30 minutes on a standard ubuntu-24.04 GitHub runner,
 whereas building for all the architectures takes over an hour.
-Building within a docker container increases this by about 50%.
 
 To build an artifactbundle for just the `x86_64` architecture, run:
 
 ```
-TARGET_ARCHS=aarch64 ./build-docker release /tmp/android-sdk
+TARGET_ARCHS=x86_64 ./build-docker release /tmp/android-sdk
 ```
 
 ## Installing and validating the SDK
@@ -66,7 +69,17 @@ The `.github/workflows/pull_request.yml` workflow
 will create and upload an installable SDK named something like:
 `swift-6.1-RELEASE_android-0.1.artifactbundle.tar.gz`
 
-The workflow will also install the SDK locally and use
+The GitHub workflow will also install the SDK locally and use
 [swift-android-action](https://github.com/marketplace/actions/swift-android-action)
 to build and test various Swift packages in an Android emulator using the
 freshly-created SDK bundle.
+
+## Building locally
+
+Instead of building within a Docker container, the script can also
+perform the build locally on an Ubuntu 24.04 machine with all the
+build prerequisites already installed. This will generate
+the same artifacts in approximately half the time, and
+may be suitable to an already containerized envrionment (such as
+a GitHub runner).
+

--- a/swift-ci/sdks/android/README.md
+++ b/swift-ci/sdks/android/README.md
@@ -39,18 +39,20 @@ fetch tagged sources for libxml2, curl, boringssl, and swift.
 
 It then applies some patches and invokes `scripts/build.sh`,
 which will build the sources for each of the specified
-architectures. Finally, it combines the NDK and the newly built
-SDKs into a single artifactbundle.  
+architectures and then combines the SDKs into a single
+artifactbundle with targetTriples for each of the supported
+architectures (`aarch64`, `x86_64`, `aarmv7`)
+and Android API levels (28-35).
 
 ## Specifying Architectures
 
 By default all the supported Android architectures
-(`aarch64`, `x86_64`, `aarmv7`)
 will be built, but this can be reduced in order to speed
 up the build. This can be useful, e.g., as part of a CI that
 validates a pull request, as building a single architecture
 takes around 30 minutes on a standard ubuntu-24.04 GitHub runner,
 whereas building for all the architectures takes over an hour.
+Building within a docker container increases this by about 50%.
 
 To build an artifactbundle for just the `x86_64` architecture, run:
 

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -12,7 +12,7 @@ TARGET_ARCHS=${TARGET_ARCHS:-aarch64,x86_64,armv7}
 ANDROID_NDK_VERSION=android-ndk-r27c
 ANDROID_API=28
 
-export BUILD_VERSION=${1}
+export BUILD_SCHEME=${1}
 # note that WORKDIR must not be under the current checkout or the patches will fail to apply
 WORKDIR=${2}
 if [[ "${WORKDIR}" == '' ]]; then

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -12,7 +12,7 @@ TARGET_ARCHS=${TARGET_ARCHS:-aarch64,x86_64,armv7}
 ANDROID_NDK_VERSION=android-ndk-r27c
 ANDROID_API=28
 
-export BUILD_VERSION=${1}
+export BUILD_SCHEME=${1}
 # note that WORKDIR must not be under the current checkout or the patches will fail to apply
 WORKDIR=${2}
 if [[ "${WORKDIR}" == '' ]]; then

--- a/swift-ci/sdks/android/scripts/patch-sources.sh
+++ b/swift-ci/sdks/android/scripts/patch-sources.sh
@@ -28,19 +28,19 @@ perl -pi -e 's;dispatch android-execinfo;dispatch;g' $swift_android_patch
 perl -pi -e 's;call ln -sf;call ln -svf;g' $swift_android_patch
 perl -pi -e 's%linux-x86_64/sysroot/usr/lib"%linux-x86_64/sysroot/usr/lib"; echo "VALIDATING SYMBOLIC LINK"; ls -la "\${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib"; ls -la "\${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift"; %g' $swift_android_patch
 
-case "${BUILD_VERSION}" in
+case "${BUILD_SCHEME}" in
     release)
         testing_patch="${patches_dir}/swift-android-testing-release.patch"
         ;;
-    devel)
+    swift-*-branch)
         testing_patch="${patches_dir}/swift-android-testing-except-release.patch"
         ;;
-    trunk)
+    development)
         testing_patch="${patches_dir}/swift-android-testing-except-release.patch"
         dispatch_patch="${patches_dir}/swift-android-trunk-libdispatch.patch"
         ;;
     *)
-        echo "$0: invalid BUILD_VERSION=${BUILD_VERSION}"
+        echo "$0: invalid BUILD_SCHEME=${BUILD_SCHEME}"
         exit 1
         ;;
 esac

--- a/swift-ci/sdks/android/scripts/toolchain-vars.sh
+++ b/swift-ci/sdks/android/scripts/toolchain-vars.sh
@@ -23,7 +23,7 @@ case "${BUILD_VERSION}" in
         ;;
     devel)
         # e.g., swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-15-a
-        SWIFT_TAG=$(curl -fsSL https://download.swift.org/swift-6.2-branch/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' '
+        SWIFT_TAG=$(curl -fsSL https://download.swift.org/swift-6.2-branch/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' ')
         SWIFT_BRANCH="swift-$(echo $SWIFT_TAG | cut -d- -f2)-branch"
         ;;
     trunk)

--- a/swift-ci/sdks/android/scripts/toolchain-vars.sh
+++ b/swift-ci/sdks/android/scripts/toolchain-vars.sh
@@ -7,32 +7,32 @@
 # ===----------------------------------------------------------------------===
 
 # This script is meant to be sourced from another script that sets the
-# BUILD_VERSION environment variable to one of "release", "devel", or "trunk"
+# BUILD_SCHEME environment variable to one of "release", "swift-VERSION-branch", or "development"
 # and will set check the latest builds for each build type in order
 # to provide information about the Swift tag name in use and where to
 # obtain the latest toolchain for building.
 
 OS=$(echo $HOST_OS | tr -d '.')
 
-case "${BUILD_VERSION}" in
+case "${BUILD_SCHEME}" in
     release)
         # e.g., "swift-6.1-RELEASE"
         SWIFT_TAG=$(curl -fsSL https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag')
         # e.g., "swift-6.1-release"
         SWIFT_BRANCH=$(echo "${SWIFT_TAG}" | tr '[A-Z]' '[a-z]')
         ;;
-    devel)
+    swift-*-branch)
         # e.g., swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-15-a
-        SWIFT_TAG=$(curl -fsSL https://download.swift.org/swift-6.2-branch/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' ')
-        SWIFT_BRANCH="swift-$(echo $SWIFT_TAG | cut -d- -f2)-branch"
+        SWIFT_TAG=$(curl -fsSL https://download.swift.org/$BUILD_SCHEME/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' ')
+        SWIFT_BRANCH=$BUILD_SCHEME
         ;;
-    trunk)
+    development)
         # e.g., swift-DEVELOPMENT-SNAPSHOT-2025-05-14-a
         SWIFT_TAG=$(curl -fsSL https://download.swift.org/development/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' ')
         SWIFT_BRANCH="development"
         ;;
     *)
-        echo "$0: invalid BUILD_VERSION=${BUILD_VERSION}"
+        echo "$0: invalid BUILD_SCHEME=${BUILD_SCHEME}"
         exit 1
         ;;
 esac

--- a/swift-ci/sdks/android/scripts/toolchain-vars.sh
+++ b/swift-ci/sdks/android/scripts/toolchain-vars.sh
@@ -12,25 +12,23 @@
 # to provide information about the Swift tag name in use and where to
 # obtain the latest toolchain for building.
 
-# TODO: we could instead use the latest-build.yml files for this, like:
-# https://download.swift.org/swift-6.2-branch/ubuntu2404/latest-build.yml
-# https://download.swift.org/development/ubuntu2404/latest-build.yml
-# but there doesn't seem to be one for the current release build.
+OS=$(echo $HOST_OS | tr -d '.')
 
 case "${BUILD_VERSION}" in
     release)
-        LATEST_TOOLCHAIN_VERSION=$(curl -sL https://github.com/swiftlang/swift/releases | grep -m1 swift-6.1 | cut -d- -f2)
-        SWIFT_TAG="swift-${LATEST_TOOLCHAIN_VERSION}-RELEASE"
-        SWIFT_BRANCH="swift-$(echo $SWIFT_TAG | cut -d- -f2)-release"
+        # e.g., "swift-6.1-RELEASE"
+        SWIFT_TAG=$(curl -fsSL https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag')
+        # e.g., "swift-6.1-release"
+        SWIFT_BRANCH=$(echo "${SWIFT_TAG}" | tr '[A-Z]' '[a-z]')
         ;;
     devel)
-        LATEST_TOOLCHAIN_VERSION=$(curl -sL https://github.com/swiftlang/swift/tags | grep -m1 swift-6.2-DEV | cut -d- -f8-10)
-        SWIFT_TAG="swift-6.2-DEVELOPMENT-SNAPSHOT-${LATEST_TOOLCHAIN_VERSION}-a"
+        # e.g., swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-15-a
+        SWIFT_TAG=$(curl -fsSL https://download.swift.org/swift-6.2-branch/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' '
         SWIFT_BRANCH="swift-$(echo $SWIFT_TAG | cut -d- -f2)-branch"
         ;;
     trunk)
-        LATEST_TOOLCHAIN_VERSION=$(curl -sL https://github.com/swiftlang/swift/tags | grep -m1 swift-DEV | cut -d- -f7-9)
-        SWIFT_TAG="swift-DEVELOPMENT-SNAPSHOT-${LATEST_TOOLCHAIN_VERSION}-a"
+        # e.g., swift-DEVELOPMENT-SNAPSHOT-2025-05-14-a
+        SWIFT_TAG=$(curl -fsSL https://download.swift.org/development/$OS/latest-build.yml | grep '^dir: ' | cut -f 2 -d ' ')
         SWIFT_BRANCH="development"
         ;;
     *)
@@ -40,5 +38,5 @@ case "${BUILD_VERSION}" in
 esac
 
 SWIFT_BASE=$SWIFT_TAG-$HOST_OS
-export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$(echo $HOST_OS | tr -d '.')/$SWIFT_TAG/$SWIFT_BASE.tar.gz"
+export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/$SWIFT_TAG/$SWIFT_BASE.tar.gz"
 


### PR DESCRIPTION
Rather than scraping the swift.org web pages, this now fetches the tags for the latest releases and snapshot builds from:

https://www.swift.org/api/v1/install/releases.json
https://download.swift.org/swift-6.2-branch/ubuntu2404/latest-build.yml
https://download.swift.org/development/ubuntu2404/latest-build.yml