### PR TITLE
Run the compiler validation suite for Android

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,15 +23,18 @@ jobs:
             *.log
 
    android-build:
-     name: Build Android ${{ matrix.build-type }} ${{ matrix.swift-version }} ${{ matrix.arch }} SDK (build-compiler=${{ matrix.build-compiler }})
+     name: Android ${{ matrix.build-type }} ${{ matrix.swift-version }} ${{ matrix.arch }} ${{ matrix.runner }} (compiler=${{ matrix.build-compiler }})
      strategy:
        fail-fast: false
        matrix:
          include:
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'docker'
+             build-compiler: '1'
+             runner: 'self-hosted'
            - swift-version: 'development'
              build-type: 'docker'
              build-compiler: '1'
-             # self-hosted runner variant
              runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'local'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,14 +28,14 @@ jobs:
        fail-fast: false
        matrix:
          include:
-           - swift-version: 'swift-6.2-branch'
-             build-type: 'docker'
-             build-compiler: '1'
-             runner: 'self-hosted'
-           - swift-version: 'development'
-             build-type: 'docker'
-             build-compiler: '1'
-             runner: 'self-hosted'
+           #- swift-version: 'swift-6.2-branch'
+           #  build-type: 'docker'
+           #  build-compiler: '1'
+           #  runner: 'self-hosted'
+           #- swift-version: 'development'
+           #  build-type: 'docker'
+           #  build-compiler: '1'
+           #  runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'docker'
              build-compiler: '0'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -168,7 +168,7 @@ jobs:
           echo 'import Android' >> Sources/DemoProject/DemoProject.swift
       - name: Test Demo Project on Android
         uses: skiptools/swift-android-action@main
-        if: false # disabled because we aren't building Testing
+        if: ${{ matrix.runner != 'self-hosted' }}
         with:
           # only test for the complete arch SDK build to speed up CI
           #run-tests: ${{ matrix.arch == '' }}
@@ -177,11 +177,13 @@ jobs:
           installed-swift: ${{ steps.info.outputs.swift-root }}
 
       - name: Checkout swift-algorithms
+        if: ${{ matrix.runner != 'self-hosted' }}
         uses: actions/checkout@v4
         with:
           repository: apple/swift-algorithms
           path: swift-algorithms
       - name: Test swift-algorithms
+        if: ${{ matrix.runner != 'self-hosted' }}
         uses: skiptools/swift-android-action@main
         with:
           package-path: swift-algorithms

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,25 +28,25 @@ jobs:
        fail-fast: false
        matrix:
          include:
-           #- swift-version: 'swift-6.2-branch'
-           #  build-type: 'docker'
-           #  build-compiler: '1'
-           #  runner: 'self-hosted'
-           #- swift-version: 'development'
-           #  build-type: 'docker'
-           #  build-compiler: '1'
-           #  runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'docker'
              build-compiler: '1'
-             runner: 'ubuntu-24.04'
+             runner: 'self-hosted'
            - swift-version: 'development'
              build-type: 'docker'
              build-compiler: '1'
+             runner: 'self-hosted'
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'docker'
+             build-compiler: '0'
+             runner: 'ubuntu-24.04'
+           - swift-version: 'development'
+             build-type: 'docker'
+             build-compiler: '0'
              runner: 'ubuntu-24.04'
      runs-on: ${{ matrix.runner }}
-     # 12 hour timeout
-     timeout-minutes: 720
+     # 15 hour timeout
+     timeout-minutes: 900
      steps:
       - name: Free Disk Space
         if: ${{ matrix.runner != 'self-hosted' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,6 +42,14 @@ jobs:
              build-type: 'local'
              build-compiler: '0'
              runner: 'ubuntu-24.04'
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'docker'
+             build-compiler: '1'
+             runner: 'ubuntu-24.04'
+           - swift-version: 'development'
+             build-type: 'docker'
+             build-compiler: '1'
+             runner: 'ubuntu-24.04'
   
      runs-on: ${{ matrix.runner }}
      steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,13 +33,21 @@ jobs:
              arch: ''
              build-compiler: '1'
              # self-hosted runner variant
-             runner: 'skip-android-runner'
+             runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'local'
              build-compiler: '0'
              runner: 'ubuntu-24.04'
            - swift-version: 'development'
              build-type: 'local'
+             build-compiler: '0'
+             runner: 'ubuntu-24.04'
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'docker'
+             build-compiler: '0'
+             runner: 'ubuntu-24.04'
+           - swift-version: 'development'
+             build-type: 'docker'
              build-compiler: '0'
              runner: 'ubuntu-24.04'
            - swift-version: 'swift-6.2-branch'
@@ -169,6 +177,7 @@ jobs:
           echo 'import Android' >> Sources/DemoProject/DemoProject.swift
       - name: Test Demo Project on Android
         uses: skiptools/swift-android-action@main
+        if: false # disabled because we aren't building Testing
         with:
           # only test for the complete arch SDK build to speed up CI
           #run-tests: ${{ matrix.arch == '' }}
@@ -184,7 +193,6 @@ jobs:
       - name: Test swift-algorithms
         uses: skiptools/swift-android-action@main
         with:
-          run-tests: ${{ matrix.arch == '' }}
           package-path: swift-algorithms
           installed-sdk: ${{ steps.info.outputs.sdk-id }}
           installed-swift: ${{ steps.info.outputs.swift-root }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,24 +28,16 @@ jobs:
        fail-fast: false
        matrix:
          #build-type: ['docker']
-         build-type: ['docker', 'local']
+         build-type: ['docker']
          #build-compiler: ['0', '1']
-         build-compiler: ['0']
+         build-compiler: ['1']
          # blank arch builds all (aarch64,x86_64,armv7)
          arch: ['']
          # builds only x86_64 to speed up the validation
          #arch: ['x86_64']
          # build both the quick (x86_64) and complete (aarch64,x86_64,armv7) SDKs
          #arch: ['x86_64', '']
-         swift-version: ['release', 'swift-6.2-branch', 'development']
-         # add docker-specific variants that run the compiler validation tests
-         include:
-           - swift-version: 'swift-6.2-branch'
-             build-type: 'docker'
-             build-compiler: '1'
-           - swift-version: 'development'
-             build-type: 'docker'
-             build-compiler: '1'
+         swift-version: ['swift-6.2-branch', 'development']
      runs-on: ubuntu-24.04
      steps:
       - name: Free Disk Space

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,22 @@ jobs:
          # build both the quick (x86_64) and complete (aarch64,x86_64,armv7) SDKs
          #arch: ['x86_64', '']
          swift-version: ['swift-6.2-branch', 'development']
-     runs-on: ubuntu-24.04
+         runner: ['ubuntu-24.04']
+         
+       include:
+         # self-hosted runner variant
+         - swift-version: 'development'
+           build-type: 'docker'
+           build-compiler: '1'
+           runner: 'skip-android-runner'
+         - swift-version: 'swift-6.2-branch'
+           build-type: 'local'
+           build-compiler: '0'
+         - swift-version: 'development'
+           build-type: 'local'
+           build-compiler: '0'
+
+     runs-on: ${{ matrix.runner }}
      steps:
       - name: Free Disk Space
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ matrix.build-type == 'local' }}
         working-directory: swift-ci/sdks/android
         run: |
-          sudo apt install -q ninja-build patchelf
+          sudo apt install -q patchelf build-essential cmake ninja-build python3 golang git gnupg2 libcurl4-openssl-dev libedit-dev libicu-dev libncurses5-dev libpython3-dev libsqlite3-dev libxml2-dev rsync uuid-dev uuid-runtime tzdata curl unzip
           ./build-local ${BUILD_SCHEME} ${WORKDIR}
       - name: Build Android SDK (Docker)
         if: ${{ matrix.build-type == 'docker' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,6 @@ jobs:
          include:
            - swift-version: 'development'
              build-type: 'docker'
-             arch: ''
              build-compiler: '1'
              # self-hosted runner variant
              runner: 'self-hosted'
@@ -62,6 +61,7 @@ jobs:
      runs-on: ${{ matrix.runner }}
      steps:
       - name: Free Disk Space
+        if: ${{ matrix.runner != 'self-hosted' }}
         run: |
           df -h
           # brings available space from 25G to 32G
@@ -145,6 +145,7 @@ jobs:
           name: ${{ steps.info.outputs.artifact-name }}
           path: ${{ steps.info.outputs.artifact-path }}
       - name: Cleanup
+        if: ${{ matrix.runner != 'self-hosted' }}
         run: |
           # need to free up some space or else when installing we get: No space left on device
           df -h
@@ -153,6 +154,7 @@ jobs:
           sudo docker builder prune -a
           df -h
       - name: Install artifactbundle
+        if: ${{ matrix.runner != 'self-hosted' }}
         shell: bash
         run: |
           set -ex
@@ -163,6 +165,7 @@ jobs:
           echo "ANDROID_NDK_ROOT=" >> $GITHUB_ENV
 
       - name: Create Demo Project
+        if: ${{ matrix.runner != 'self-hosted' }}
         run: |
           cd ${{ runner.temp }}
           mkdir DemoProject

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,9 +40,6 @@ jobs:
          swift-version: ['release', 'swift-6.2-branch', 'development']
          # add docker-specific variants that run the compiler validation tests
          include:
-           - swift-version: 'release'
-             build-type: 'docker'
-             build-compiler: '1'
            - swift-version: 'swift-6.2-branch'
              build-type: 'docker'
              build-compiler: '1'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,7 +44,7 @@ jobs:
           df -h
           # brings available space from 25G to 32G
           # otherwise we sometimes run out of space during the build
-          sudo rm -rf /usr/share/miniconda /usr/share/az* /usr/share/glade* /usr/local/share/chromium /usr/local/share/powershell /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/miniconda /usr/share/az* /usr/share/glade* /usr/local/share/chromium /usr/local/share/powershell /usr/share/dotnet /opt/ghc /opt/hostedtoolcache /usr/local/graalvm/ /usr/local/.ghcup/ /usr/local/lib/node_modules /usr/local/share/boost
           sudo docker image prune --all --force
           sudo docker builder prune -a
           df -h

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,12 +23,13 @@ jobs:
             *.log
 
    android-build:
-     name: Build Android ${{ matrix.build-type }} ${{ matrix.swift-version }} ${{ matrix.arch }} SDK
+     name: Build Android ${{ matrix.build-type }} ${{ matrix.swift-version }} ${{ matrix.arch }} SDK (build-compiler=${{ matrix.build-compiler }})
      strategy:
        fail-fast: false
        matrix:
          #build-type: ['docker']
          build-type: ['docker', 'local']
+         build-compiler: ['0', '1']
          # blank arch builds all (aarch64,x86_64,armv7)
          #arch: ['']
          # builds only x86_64 to speed up the validation
@@ -53,6 +54,8 @@ jobs:
           # these variabes are used by build-docker and build-local
           # to determine which Swift version to build for
           echo "BUILD_SCHEME=${{ matrix.swift-version }}" >> $GITHUB_ENV
+          # pass the build-compiler matrix through to the build script
+          echo "BUILD_COMPILER=${{ matrix.build-compiler }}" >> $GITHUB_ENV
           echo "TARGET_ARCHS=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "WORKDIR=${{ runner.temp }}/swift-android-sdk" >> $GITHUB_ENV
       - name: Checkout repository
@@ -98,6 +101,9 @@ jobs:
           # depending on whether we are building locally or in a container, add a maker to the name
           if [[ "${{ matrix.build-type }}" == 'local' ]]; then
             ARTIFACT_NAME="${ARTIFACT_NAME}-local"
+          fi
+          if [[ "${{ matrix.build-compiler }}" == '1' ]]; then
+            ARTIFACT_NAME="${ARTIFACT_NAME}-hostbuild"
           fi
           # artifacts need a unique name so we suffix with the matrix arch(s)
           if [[ ! -z "${{ matrix.arch }}" ]]; then

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,11 +38,11 @@ jobs:
            #  runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'docker'
-             build-compiler: '0'
+             build-compiler: '1'
              runner: 'ubuntu-24.04'
            - swift-version: 'development'
              build-type: 'docker'
-             build-compiler: '0'
+             build-compiler: '1'
              runner: 'ubuntu-24.04'
      runs-on: ${{ matrix.runner }}
      # 12 hour timeout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,30 +27,21 @@ jobs:
      strategy:
        fail-fast: false
        matrix:
-         #build-type: ['docker']
-         build-type: ['docker']
-         #build-compiler: ['0', '1']
-         build-compiler: ['1']
-         # blank arch builds all (aarch64,x86_64,armv7)
-         arch: ['']
-         # builds only x86_64 to speed up the validation
-         #arch: ['x86_64']
-         # build both the quick (x86_64) and complete (aarch64,x86_64,armv7) SDKs
-         #arch: ['x86_64', '']
-         swift-version: ['swift-6.2-branch', 'development']
-         runner: ['ubuntu-24.04']
          include:
-           # self-hosted runner variant
            - swift-version: 'development'
              build-type: 'docker'
+             arch: ''
              build-compiler: '1'
+             # self-hosted runner variant
              runner: 'skip-android-runner'
            - swift-version: 'swift-6.2-branch'
              build-type: 'local'
              build-compiler: '0'
+             runner: 'ubuntu-24.04'
            - swift-version: 'development'
              build-type: 'local'
              build-compiler: '0'
+             runner: 'ubuntu-24.04'
   
      runs-on: ${{ matrix.runner }}
      steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,20 +39,19 @@ jobs:
          #arch: ['x86_64', '']
          swift-version: ['swift-6.2-branch', 'development']
          runner: ['ubuntu-24.04']
-         
-       include:
-         # self-hosted runner variant
-         - swift-version: 'development'
-           build-type: 'docker'
-           build-compiler: '1'
-           runner: 'skip-android-runner'
-         - swift-version: 'swift-6.2-branch'
-           build-type: 'local'
-           build-compiler: '0'
-         - swift-version: 'development'
-           build-type: 'local'
-           build-compiler: '0'
-
+         include:
+           # self-hosted runner variant
+           - swift-version: 'development'
+             build-type: 'docker'
+             build-compiler: '1'
+             runner: 'skip-android-runner'
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'local'
+             build-compiler: '0'
+           - swift-version: 'development'
+             build-type: 'local'
+             build-compiler: '0'
+  
      runs-on: ${{ matrix.runner }}
      steps:
       - name: Free Disk Space

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,30 +28,14 @@ jobs:
        fail-fast: false
        matrix:
          include:
-           - swift-version: 'swift-6.2-branch'
-             build-type: 'docker'
-             build-compiler: '1'
-             runner: 'self-hosted'
-           - swift-version: 'development'
-             build-type: 'docker'
-             build-compiler: '1'
-             runner: 'self-hosted'
-           - swift-version: 'swift-6.2-branch'
-             build-type: 'local'
-             build-compiler: '0'
-             runner: 'ubuntu-24.04'
-           - swift-version: 'development'
-             build-type: 'local'
-             build-compiler: '0'
-             runner: 'ubuntu-24.04'
-           - swift-version: 'swift-6.2-branch'
-             build-type: 'docker'
-             build-compiler: '0'
-             runner: 'ubuntu-24.04'
-           - swift-version: 'development'
-             build-type: 'docker'
-             build-compiler: '0'
-             runner: 'ubuntu-24.04'
+           # - swift-version: 'swift-6.2-branch'
+           # build-type: 'docker'
+           # build-compiler: '1'
+           # runner: 'self-hosted'
+           #- swift-version: 'development'
+           #  build-type: 'docker'
+           #  build-compiler: '1'
+           #  runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'docker'
              build-compiler: '1'
@@ -60,7 +44,6 @@ jobs:
              build-type: 'docker'
              build-compiler: '1'
              runner: 'ubuntu-24.04'
-  
      runs-on: ${{ matrix.runner }}
      steps:
       - name: Free Disk Space

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,14 +29,26 @@ jobs:
        matrix:
          #build-type: ['docker']
          build-type: ['docker', 'local']
-         build-compiler: ['0', '1']
+         #build-compiler: ['0', '1']
+         build-compiler: ['0']
          # blank arch builds all (aarch64,x86_64,armv7)
-         #arch: ['']
+         arch: ['']
          # builds only x86_64 to speed up the validation
          #arch: ['x86_64']
          # build both the quick (x86_64) and complete (aarch64,x86_64,armv7) SDKs
-         arch: ['x86_64', '']
+         #arch: ['x86_64', '']
          swift-version: ['release', 'swift-6.2-branch', 'development']
+         # add docker-specific variants that run the compiler validation tests
+         include:
+           - swift-version: 'release'
+             build-type: 'docker'
+             build-compiler: '1'
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'docker'
+             build-compiler: '1'
+           - swift-version: 'development'
+             build-type: 'docker'
+             build-compiler: '1'
      runs-on: ubuntu-24.04
      steps:
       - name: Free Disk Space

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,23 +28,25 @@ jobs:
        fail-fast: false
        matrix:
          include:
-           # - swift-version: 'swift-6.2-branch'
-           # build-type: 'docker'
-           # build-compiler: '1'
-           # runner: 'self-hosted'
-           #- swift-version: 'development'
-           #  build-type: 'docker'
-           #  build-compiler: '1'
-           #  runner: 'self-hosted'
            - swift-version: 'swift-6.2-branch'
              build-type: 'docker'
              build-compiler: '1'
-             runner: 'ubuntu-24.04'
+             runner: 'self-hosted'
            - swift-version: 'development'
              build-type: 'docker'
              build-compiler: '1'
+             runner: 'self-hosted'
+           - swift-version: 'swift-6.2-branch'
+             build-type: 'docker'
+             build-compiler: '0'
+             runner: 'ubuntu-24.04'
+           - swift-version: 'development'
+             build-type: 'docker'
+             build-compiler: '0'
              runner: 'ubuntu-24.04'
      runs-on: ${{ matrix.runner }}
+     # 12 hour timeout
+     timeout-minutes: 720
      steps:
       - name: Free Disk Space
         if: ${{ matrix.runner != 'self-hosted' }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Docker images for [Swift](https://swift.org).
 
-#### You can find the Docker Hub repo here: [https://hub.docker.com/_/swift/](https://hub.docker.com/_/swift/)
+#### You can find the  Hub repo here: [https://hub.docker.com/_/swift/](https://hub.docker.com/_/swift/)
 
 #### Nightly image tags are published here: [https://hub.docker.com/r/swiftlang/swift](https://hub.docker.com/r/swiftlang/swift)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
 
-### Docker images for [Swift](https://swift.org).
+###  images for [Swift](https://swift.org).
 
 #### You can find the  Hub repo here: [https://hub.docker.com/_/swift/](https://hub.docker.com/_/swift/)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
 
-###  images for [Swift](https://swift.org).
+### Docker images for [Swift](https://swift.org).
 
-#### You can find the  Hub repo here: [https://hub.docker.com/_/swift/](https://hub.docker.com/_/swift/)
+#### You can find the Docker Hub repo here: [https://hub.docker.com/_/swift/](https://hub.docker.com/_/swift/)
 
 #### Nightly image tags are published here: [https://hub.docker.com/r/swiftlang/swift](https://hub.docker.com/r/swiftlang/swift)
 

--- a/swift-ci/sdks/android/Dockerfile
+++ b/swift-ci/sdks/android/Dockerfile
@@ -18,6 +18,7 @@ ARG SWIFT_TOOLCHAIN_URL=
 RUN apt-get -q update \
     && DEBIAN_FRONTEND=noninteractive apt-get -q install -y \
     build-essential \
+    clang \
     cmake \
     ninja-build \
     python3 \

--- a/swift-ci/sdks/android/Dockerfile
+++ b/swift-ci/sdks/android/Dockerfile
@@ -54,7 +54,8 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 COPY scripts/install-swift.sh /scripts/install-swift.sh
 RUN chmod ugo+x /scripts/install-swift.sh
 RUN /scripts/install-swift.sh /usr/local/swift
-ENV PATH="/usr/local/swift/bin:${PATH}"
+#ENV PATH="/usr/local/swift/bin:${PATH}"
+ENV PATH="${PATH}:/usr/local/swift/bin"
 
 ARG ANDROID_NDK_VERSION=
 

--- a/swift-ci/sdks/android/Dockerfile
+++ b/swift-ci/sdks/android/Dockerfile
@@ -18,7 +18,7 @@ ARG SWIFT_TOOLCHAIN_URL=
 RUN apt-get -q update \
     && DEBIAN_FRONTEND=noninteractive apt-get -q install -y \
     build-essential \
-    clang \
+    clang-19 \
     cmake \
     ninja-build \
     python3 \
@@ -55,8 +55,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 COPY scripts/install-swift.sh /scripts/install-swift.sh
 RUN chmod ugo+x /scripts/install-swift.sh
 RUN /scripts/install-swift.sh /usr/local/swift
-#ENV PATH="/usr/local/swift/bin:${PATH}"
-ENV PATH="${PATH}:/usr/local/swift/bin"
+ENV PATH="/usr/lib/llvm-19/bin:/usr/local/swift/bin:${PATH}"
 
 ARG ANDROID_NDK_VERSION=
 

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -7,7 +7,7 @@
 # ===----------------------------------------------------------------------===
 
 # default architectures to build for
-TARGET_ARCHS=${TARGET_ARCHS:-armv7}
+TARGET_ARCHS=${TARGET_ARCHS:-aarch64,armv7}
 
 ANDROID_NDK_VERSION=android-ndk-r27c
 ANDROID_API=28

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -7,7 +7,7 @@
 # ===----------------------------------------------------------------------===
 
 # default architectures to build for
-TARGET_ARCHS=${TARGET_ARCHS:-armv7}
+TARGET_ARCHS=${TARGET_ARCHS:-aarch64,x86_64,armv7}
 
 ANDROID_NDK_VERSION=android-ndk-r27c
 ANDROID_API=28

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -27,7 +27,7 @@ source ./scripts/toolchain-vars.sh
 
 # Check-out and patch the sources
 ./scripts/fetch-source.sh --source-dir ${WORKDIR}/source --swift-tag ${SWIFT_TAG}
-${WORKDIR}/source/swift-android-patches/apply-patches.sh ${WORKDIR}/source/swift-project
+${WORKDIR}/patches/apply-patches.sh ${WORKDIR}/source/swift-project
 
 mkdir -p ${WORKDIR}/products
 chmod ugo+rwx ${WORKDIR}/products

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -62,6 +62,7 @@ $DOCKER run -i --rm \
             --source-dir /source \
             --products-dir /products \
             --host-toolchain /usr/local/swift \
+            --build-compiler ${BUILD_COMPILER} \
             --android-api ${ANDROID_API} \
             --ndk-home /usr/local/ndk/${ANDROID_NDK_VERSION} \
             --archs ${TARGET_ARCHS}

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -7,7 +7,7 @@
 # ===----------------------------------------------------------------------===
 
 # default architectures to build for
-TARGET_ARCHS=${TARGET_ARCHS:-aarch64,x86_64,armv7}
+TARGET_ARCHS=${TARGET_ARCHS:-armv7}
 
 ANDROID_NDK_VERSION=android-ndk-r27c
 ANDROID_API=28

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -27,7 +27,7 @@ source ./scripts/toolchain-vars.sh
 
 # Check-out and patch the sources
 ./scripts/fetch-source.sh --source-dir ${WORKDIR}/source --swift-tag ${SWIFT_TAG}
-${WORKDIR}/patches/apply-patches.sh ${WORKDIR}/source/swift-project
+./patches/apply-patches.sh ${WORKDIR}/source/swift-project
 
 mkdir -p ${WORKDIR}/products
 chmod ugo+rwx ${WORKDIR}/products

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -59,10 +59,10 @@ $DOCKER run -i --rm \
           -v ${WORKDIR}/products:/products:rw \
           ${CONTAINER_NAME} \
           /scripts/build.sh \
-            --source-dir /source \
-            --products-dir /products \
-            --host-toolchain /usr/local/swift \
-            --build-compiler ${BUILD_COMPILER} \
-            --android-api ${ANDROID_API} \
-            --ndk-home /usr/local/ndk/${ANDROID_NDK_VERSION} \
-            --archs ${TARGET_ARCHS}
+            --source-dir "/source" \
+            --products-dir "/products" \
+            --host-toolchain "/usr/local/swift" \
+            --build-compiler "${BUILD_COMPILER}" \
+            --android-api "${ANDROID_API}" \
+            --ndk-home "/usr/local/ndk/${ANDROID_NDK_VERSION}" \
+            --archs "${TARGET_ARCHS}"

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -7,7 +7,7 @@
 # ===----------------------------------------------------------------------===
 
 # default architectures to build for
-TARGET_ARCHS=${TARGET_ARCHS:-aarch64,armv7}
+TARGET_ARCHS=${TARGET_ARCHS:-armv7}
 
 ANDROID_NDK_VERSION=android-ndk-r27c
 ANDROID_API=28

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -25,7 +25,7 @@ WORKDIR=$(realpath ${WORKDIR})
 HOST_OS=ubuntu$(lsb_release -sr)
 source ./scripts/toolchain-vars.sh
 
-if [[ "${BUILD_COMPILER}" != "0" ]]; then
+if [[ "${BUILD_COMPILER}" != "1" ]]; then
     SWIFT_ROOT=${WORKDIR}/host-toolchain
     HOST_TOOLCHAIN=$SWIFT_ROOT/$SWIFT_BASE/usr
     if [[ ! -d "$HOST_TOOLCHAIN" ]]; then

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -58,6 +58,7 @@ mkdir -p ${WORKDIR}/products
     --source-dir ${WORKDIR}/source \
     --products-dir ${WORKDIR}/products \
     --build-dir ${WORKDIR}/build \
+    --build-compiler ${BUILD_COMPILER} \
     --host-toolchain ${HOST_TOOLCHAIN} \
     --android-api ${ANDROID_API} \
     --ndk-home ${ANDROID_NDK_HOME} \

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -57,11 +57,11 @@ ${WORKDIR}/source/swift-android-patches/apply-patches.sh ${WORKDIR}/source/swift
 mkdir -p ${WORKDIR}/products
 
 ./scripts/build.sh \
-    --source-dir ${WORKDIR}/source \
-    --products-dir ${WORKDIR}/products \
-    --build-dir ${WORKDIR}/build \
-    --build-compiler ${BUILD_COMPILER} \
-    --host-toolchain ${HOST_TOOLCHAIN} \
-    --android-api ${ANDROID_API} \
-    --ndk-home ${ANDROID_NDK_HOME} \
-    --archs ${TARGET_ARCHS}
+    --source-dir "${WORKDIR}/source" \
+    --products-dir "${WORKDIR}/products" \
+    --build-dir "${WORKDIR}/build" \
+    --build-compiler "${BUILD_COMPILER}" \
+    --host-toolchain "${HOST_TOOLCHAIN}" \
+    --android-api "${ANDROID_API}" \
+    --ndk-home "${ANDROID_NDK_HOME}" \
+    --archs "${TARGET_ARCHS}"

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -52,7 +52,7 @@ fi
 
 # Check-out and patch the sources
 ./scripts/fetch-source.sh --source-dir ${WORKDIR}/source --swift-tag ${SWIFT_TAG}
-${WORKDIR}/source/swift-android-patches/apply-patches.sh ${WORKDIR}/source/swift-project
+${WORKDIR}/patches/apply-patches.sh ${WORKDIR}/source/swift-project
 
 mkdir -p ${WORKDIR}/products
 

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -25,16 +25,18 @@ WORKDIR=$(realpath ${WORKDIR})
 HOST_OS=ubuntu$(lsb_release -sr)
 source ./scripts/toolchain-vars.sh
 
-SWIFT_ROOT=${WORKDIR}/host-toolchain
-HOST_TOOLCHAIN=$SWIFT_ROOT/$SWIFT_BASE/usr
-if [[ ! -d "$HOST_TOOLCHAIN" ]]; then
-    ./scripts/install-swift.sh ${HOST_TOOLCHAIN}
+if [[ "${BUILD_COMPILER}" != "0" ]]; then
+    SWIFT_ROOT=${WORKDIR}/host-toolchain
+    HOST_TOOLCHAIN=$SWIFT_ROOT/$SWIFT_BASE/usr
+    if [[ ! -d "$HOST_TOOLCHAIN" ]]; then
+        ./scripts/install-swift.sh ${HOST_TOOLCHAIN}
+    fi
+
+    $HOST_TOOLCHAIN/bin/swift --version
+
+    # ensure the correct Swift is first in the PATH
+    export PATH=$HOST_TOOLCHAIN/bin:$PATH
 fi
-
-$HOST_TOOLCHAIN/bin/swift --version
-
-# ensure the correct Swift is first in the PATH
-export PATH=$HOST_TOOLCHAIN/bin:$PATH
 
 export ANDROID_NDK_HOME=${WORKDIR}/ndk/${ANDROID_NDK_VERSION}
 

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -52,7 +52,7 @@ fi
 
 # Check-out and patch the sources
 ./scripts/fetch-source.sh --source-dir ${WORKDIR}/source --swift-tag ${SWIFT_TAG}
-${WORKDIR}/patches/apply-patches.sh ${WORKDIR}/source/swift-project
+./patches/apply-patches.sh ${WORKDIR}/source/swift-project
 
 mkdir -p ${WORKDIR}/products
 

--- a/swift-ci/sdks/android/patches/apply-patches.sh
+++ b/swift-ci/sdks/android/patches/apply-patches.sh
@@ -3,18 +3,7 @@
 patches_dir=$(dirname $(realpath -- "${BASH_SOURCE[0]}"))
 cd ${1}
 
-# patch the patch, which seems to only be needed for an API less than 28
-# https://github.com/finagolfin/swift-android-sdk/blob/main/swift-android.patch#L110
-perl -pi -e 's/#if os\(Windows\)/#if os\(Android\)/g' ${patches_dir}/swift-android.patch
-
-# remove the need to link in android-execinfo
-perl -pi -e 's;dispatch android-execinfo;dispatch;g' ${patches_dir}/swift-android.patch
-
 case "${BUILD_SCHEME}" in
-    release)
-        git apply -v -C1 ${patches_dir}/swift-android.patch
-        git apply -v -C1 ${patches_dir}/swift-android-testing-release.patch
-        ;;
     swift-*-branch)
         git apply -v -C1 ${patches_dir}/swift-android.patch
         git apply -v -C1 ${patches_dir}/swift-android-testing-except-release.patch
@@ -30,7 +19,6 @@ case "${BUILD_SCHEME}" in
         ;;
 esac
 
-perl -pi -e 's%String\(cString: getpass%\"fake\" //%' swiftpm/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
 

--- a/swift-ci/sdks/android/patches/apply-patches.sh
+++ b/swift-ci/sdks/android/patches/apply-patches.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -ex
+
+patches_dir=$(dirname $(realpath -- "${BASH_SOURCE[0]}"))
+cd ${1}
+
+# patch the patch, which seems to only be needed for an API less than 28
+# https://github.com/finagolfin/swift-android-sdk/blob/main/swift-android.patch#L110
+perl -pi -e 's/#if os\(Windows\)/#if os\(Android\)/g' ${patches_dir}/swift-android.patch
+
+# remove the need to link in android-execinfo
+perl -pi -e 's;dispatch android-execinfo;dispatch;g' ${patches_dir}/swift-android.patch
+
+case "${BUILD_SCHEME}" in
+    release)
+        git apply -v -C1 ${patches_dir}/swift-android.patch
+        git apply -v -C1 ${patches_dir}/swift-android-testing-release.patch
+        ;;
+    swift-*-branch)
+        git apply -v -C1 ${patches_dir}/swift-android.patch
+        git apply -v -C1 ${patches_dir}/swift-android-testing-except-release.patch
+        ;;
+    development)
+        git apply -v -C1 ${patches_dir}/swift-android.patch
+        git apply -v -C1 ${patches_dir}/swift-android-trunk-libdispatch.patch
+        git apply -v -C1 ${patches_dir}/swift-android-testing-except-release.patch
+        ;;
+    *)
+        echo "$0: invalid BUILD_SCHEME=${BUILD_SCHEME}"
+        exit 1
+        ;;
+esac
+
+perl -pi -e 's%String\(cString: getpass%\"fake\" //%' swiftpm/Sources/PackageRegistryCommand/PackageRegistryCommand+Auth.swift
+# disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
+perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
+
+# need to un-apply libandroid-spawn since we don't need it for API28+
+perl -pi -e 's;MATCHES "Android";MATCHES "AndroidDISABLED";g' llbuild/lib/llvm/Support/CMakeLists.txt
+perl -pi -e 's; STREQUAL Android\); STREQUAL AndroidDISABLED\);g' swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
+
+

--- a/swift-ci/sdks/android/patches/apply-patches.sh
+++ b/swift-ci/sdks/android/patches/apply-patches.sh
@@ -21,9 +21,3 @@ esac
 
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
-
-# need to un-apply libandroid-spawn since we don't need it for API28+
-perl -pi -e 's;MATCHES "Android";MATCHES "AndroidDISABLED";g' llbuild/lib/llvm/Support/CMakeLists.txt
-perl -pi -e 's; STREQUAL Android\); STREQUAL AndroidDISABLED\);g' swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
-
-

--- a/swift-ci/sdks/android/patches/swift-android-testing-except-release.patch
+++ b/swift-ci/sdks/android/patches/swift-android-testing-except-release.patch
@@ -111,6 +111,19 @@ index f7f2664b2de..01d36e127c6 100644
  
  // CHECK-DISABLED-NOT: normal_count
  
+diff --git a/swift/utils/swift_build_support/swift_build_support/products/product.py b/swift/utils/swift_build_support/swift_build_support/products/product.py
+index 274b6037305..bf0f7fcf671 100644
+--- a/swift/utils/swift_build_support/swift_build_support/products/product.py
++++ b/swift/utils/swift_build_support/swift_build_support/products/product.py
+@@ -212,7 +212,7 @@ class Product(object):
+         if self.args.cross_compile_hosts:
+             if self.is_darwin_host(host_target):
+                 install_destdir = self.host_install_destdir(host_target)
+-            else:
++            elif self.args.cross_compile_append_host_target_to_destdir:
+                 install_destdir = os.path.join(install_destdir, self.args.host_target)
+         return targets.toolchain_path(install_destdir,
+                                       self.args.install_prefix)
 diff --git a/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake b/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake
 index 468dc61..a90ae3d 100644
 --- a/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake

--- a/swift-ci/sdks/android/patches/swift-android-testing-except-release.patch
+++ b/swift-ci/sdks/android/patches/swift-android-testing-except-release.patch
@@ -1,0 +1,143 @@
+diff --git a/swift/test/ClangImporter/pcm-emit-direct-cc1-mode.swift b/swift/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
+index f5048b9e3d5..c227ef7b77d 100644
+--- a/swift/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
++++ b/swift/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
+@@ -9,7 +9,7 @@
+ // CHECK-DUMP:   Module map file: {{.*[/\\]}}Inputs{{/|\\}}custom-modules{{/|\\}}module.modulemap
+ 
+ // Verify that the clang command-line used is cc1
+-// RUN: %FileCheck -check-prefix CHECK-CLANG -DTRIPLE=%target-triple %s < %t.diags.txt
++// RUN: %FileCheck -check-prefix CHECK-CLANG -DTRIPLE=%module-target-triple %s < %t.diags.txt
+ // CHECK-CLANG: clang importer cc1 args
+ // CHECK-CLANG-SAME: '-o' '{{.*[/\\]}}script.pcm' '-fsyntax-only' '-x' 'objective-c' '{{.*[/\\]}}module.modulemap' '-triple' '[[TRIPLE]]'
+ // CHECK-CLANG-SAME: '-fmodules'
+diff --git a/swift/test/IRGen/abitypes_arm.swift b/swift/test/IRGen/abitypes_arm.swift
+index 9428294483d..52bd8b10145 100644
+--- a/swift/test/IRGen/abitypes_arm.swift
++++ b/swift/test/IRGen/abitypes_arm.swift
+@@ -11,6 +11,6 @@ class Foo {
+   }
+ }
+ 
+-// armv7: define internal void @makeOne(ptr noalias sret({{.*}}) align 4 %agg.result, float{{( noundef)?}} %f, float{{( noundef)?}} %s)
++// armv7: define internal void @makeOne(ptr{{( dead_on_unwind)?}} noalias{{( writable)?}} sret({{.*}}) align 4 %agg.result, float{{( noundef)?}} %f, float{{( noundef)?}} %s)
+ // armv7s: define internal void @makeOne(ptr noalias sret({{.*}}) align 4 %agg.result, float %f, float %s)
+ // armv7k: define internal %struct.One @makeOne(float {{.*}}%f, float {{.*}}%s)
+diff --git a/swift/test/Interop/Cxx/class/constructors-copy-module-interface.swift b/swift/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+index 042c10e7d1d..254f6543b58 100644
+--- a/swift/test/Interop/Cxx/class/constructors-copy-module-interface.swift
++++ b/swift/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+@@ -1,4 +1,5 @@
+ // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
++// XFAIL: OS=linux-androideabi
+ 
+ // CHECK: struct TemplatedCopyConstructor
+ // CHECK: struct TemplatedCopyConstructorWithExtraArg
+diff --git a/swift/test/Interop/Cxx/class/constructors-diagnostics.swift b/swift/test/Interop/Cxx/class/constructors-diagnostics.swift
+index aac01480660..8fa99fae7fb 100644
+--- a/swift/test/Interop/Cxx/class/constructors-diagnostics.swift
++++ b/swift/test/Interop/Cxx/class/constructors-diagnostics.swift
+@@ -2,6 +2,7 @@
+ 
+ // This test uses -verify-additional-file, which do not work well on Windows.
+ // UNSUPPORTED: OS=windows-msvc
++// XFAIL: OS=linux-androideabi
+ 
+ import Constructors
+ 
+diff --git a/swift/test/Interop/Cxx/class/constructors-module-interface.swift b/swift/test/Interop/Cxx/class/constructors-module-interface.swift
+index bf189b6e302..d2c3d65f03e 100644
+--- a/swift/test/Interop/Cxx/class/constructors-module-interface.swift
++++ b/swift/test/Interop/Cxx/class/constructors-module-interface.swift
+@@ -1,4 +1,5 @@
+ // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
++// XFAIL: OS=linux-androideabi
+ 
+ // CHECK:      struct ExplicitDefaultConstructor {
+ // CHECK-NEXT:   init()
+diff --git a/swift/test/Interop/Cxx/class/constructors-silgen.swift b/swift/test/Interop/Cxx/class/constructors-silgen.swift
+index b1624ccccfe..79cbdf170de 100644
+--- a/swift/test/Interop/Cxx/class/constructors-silgen.swift
++++ b/swift/test/Interop/Cxx/class/constructors-silgen.swift
+@@ -1,4 +1,5 @@
+ // RUN: %target-swiftxx-frontend -I %S/Inputs -Xllvm -sil-print-types -emit-silgen %s | %FileCheck %s
++// XFAIL: OS=linux-androideabi
+ 
+ import Constructors
+ 
+diff --git a/swift/test/Interop/Cxx/class/constructors-typechecker.swift b/swift/test/Interop/Cxx/class/constructors-typechecker.swift
+index 8ce10b1ca75..52ff4104b83 100644
+--- a/swift/test/Interop/Cxx/class/constructors-typechecker.swift
++++ b/swift/test/Interop/Cxx/class/constructors-typechecker.swift
+@@ -1,4 +1,5 @@
+ // RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
++// XFAIL: OS=linux-androideabi
+ 
+ import Constructors
+ 
+diff --git a/swift/test/Interop/Cxx/class/custom-new-operator-irgen.swift b/swift/test/Interop/Cxx/class/custom-new-operator-irgen.swift
+index 74e692c9db2..0423493afac 100644
+--- a/swift/test/Interop/Cxx/class/custom-new-operator-irgen.swift
++++ b/swift/test/Interop/Cxx/class/custom-new-operator-irgen.swift
+@@ -5,4 +5,4 @@ import CustomNewOperator
+ var x = callsCustomNew()
+ 
+ // Make sure the definition of `operator new` is emitted.
+-// CHECK: define {{.*}} @{{_ZnwmPv15container_new_t|"\?\?2@YAPEAX_KPEAXUcontainer_new_t@@@Z"}}
++// CHECK: define {{.*}} @{{_Znw(j|m)Pv15container_new_t|"\?\?2@YAPEAX_KPEAXUcontainer_new_t@@@Z"}}
+diff --git a/swift/test/SILOptimizer/package-cmo-serialize-tables.swift b/swift/test/SILOptimizer/package-cmo-serialize-tables.swift
+index 382ff2e8080..f061374b2a1 100644
+--- a/swift/test/SILOptimizer/package-cmo-serialize-tables.swift
++++ b/swift/test/SILOptimizer/package-cmo-serialize-tables.swift
+@@ -19,7 +19,7 @@
+ 
+ // Temporarily disabling on watchOS (both arm64_32 & armv7k):
+ // rdar://140330692 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed...
+-// UNSUPPORTED: OS=watchos
++// UNSUPPORTED: OS=watchos, OS=linux-androideabi
+ 
+ //--- main.swift
+ 
+diff --git a/swift/test/SILOptimizer/throws_prediction.swift b/swift/test/SILOptimizer/throws_prediction.swift
+index f7f2664b2de..01d36e127c6 100644
+--- a/swift/test/SILOptimizer/throws_prediction.swift
++++ b/swift/test/SILOptimizer/throws_prediction.swift
+@@ -16,7 +16,7 @@
+ // RUN:   -sil-verify-all -module-name=test -emit-sil \
+ // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
+ 
+-// UNSUPPORTED: CPU=armv7k || CPU=arm64_32
++// UNSUPPORTED: CPU=armv7k, CPU=arm64_32, CPU=armv7
+ 
+ // CHECK-DISABLED-NOT: normal_count
+ 
+diff --git a/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake b/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake
+index 468dc61..a90ae3d 100644
+--- a/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake
++++ b/swift-corelibs-xctest/cmake/modules/PlatformInfo.cmake
+@@ -2,6 +2,10 @@
+ set(print_target_info_invocation "${CMAKE_Swift_COMPILER}" -print-target-info)
+ if(CMAKE_Swift_COMPILER_TARGET)
+   list(APPEND print_target_info_invocation -target ${CMAKE_Swift_COMPILER_TARGET})
++else()
++  set(arg_list ${CMAKE_Swift_FLAGS})
++  separate_arguments(arg_list)
++  list(APPEND print_target_info_invocation ${arg_list})
+ endif()
+ execute_process(COMMAND ${print_target_info_invocation} OUTPUT_VARIABLE target_info_json)
+ message(CONFIGURE_LOG "Swift Target Info: ${print_target_info_invocation}\n"
+diff --git a/swift-testing/cmake/modules/PlatformInfo.cmake b/swift-testing/cmake/modules/PlatformInfo.cmake
+index 94c60ef..ab8a491 100644
+--- a/swift-testing/cmake/modules/PlatformInfo.cmake
++++ b/swift-testing/cmake/modules/PlatformInfo.cmake
+@@ -9,6 +9,10 @@
+ set(print_target_info_invocation "${CMAKE_Swift_COMPILER}" -print-target-info)
+ if(CMAKE_Swift_COMPILER_TARGET)
+   list(APPEND print_target_info_invocation -target ${CMAKE_Swift_COMPILER_TARGET})
++else()
++  set(arg_list ${CMAKE_Swift_FLAGS})
++  separate_arguments(arg_list)
++  list(APPEND print_target_info_invocation ${arg_list})
+ endif()
+ execute_process(COMMAND ${print_target_info_invocation} OUTPUT_VARIABLE target_info_json)
+ message(CONFIGURE_LOG "Swift Target Info: ${print_target_info_invocation}\n"

--- a/swift-ci/sdks/android/patches/swift-android-testing-release.patch
+++ b/swift-ci/sdks/android/patches/swift-android-testing-release.patch
@@ -1,0 +1,61 @@
+diff --git a/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py b/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py
+index b6bfa5760ef..324d1a77eea 100644
+--- a/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py
++++ b/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py
+@@ -51,7 +51,7 @@ class SwiftTesting(product.Product):
+         return False
+ 
+     def should_install(self, host_target):
+-        return self.args.install_swift_testing_macros
++        return self.args.install_swift_testing
+ 
+     def _cmake_product(self, host_target):
+         build_root = os.path.dirname(self.build_dir)
+diff --git a/swift-corelibs-foundation/Sources/CoreFoundation/CFPlatform.c b/swift-corelibs-foundation/Sources/CoreFoundation/CFPlatform.c
+index 90f4aa78..0429425b 100644
+--- a/swift-corelibs-foundation/Sources/CoreFoundation/CFPlatform.c
++++ b/swift-corelibs-foundation/Sources/CoreFoundation/CFPlatform.c
+@@ -1948,7 +1948,7 @@ CF_CROSS_PLATFORM_EXPORT void *_CFReallocf(void *ptr, size_t size) {
+ #endif
+ }
+ 
+-#if TARGET_OS_ANDROID
++#if TARGET_OS_ANDROID && __ANDROID_API__ < 28
+ 
+ #include <dlfcn.h>
+ #include <spawn.h>
+@@ -2277,6 +2277,10 @@ CF_EXPORT int _CFPosixSpawnFileActionsAddClose(_CFPosixSpawnFileActionsRef file_
+     return _CFPosixSpawnFileActionsAddCloseImpl(file_actions, filedes);
+ }
+ 
++CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_actions, const char *path) {
++  return ENOSYS;
++}
++
+ CF_EXPORT int _CFPosixSpawn(pid_t *_CF_RESTRICT pid, const char *_CF_RESTRICT path, _CFPosixSpawnFileActionsRef file_actions, _CFPosixSpawnAttrRef _Nullable _CF_RESTRICT attrp, char *_Nullable const argv[_Nullable _CF_RESTRICT], char *_Nullable const envp[_Nullable _CF_RESTRICT]) {
+     _CFPosixSpawnInitialize();
+     return _CFPosixSpawnImpl(pid, path, file_actions, attrp, argv, envp);
+@@ -2279,7 +2279,7 @@ CF_EXPORT int _CFPosixSpawnFileActionsAddClose(_CFPosixSpawnFileActionsRef file_
+ }
+ 
+ CF_EXPORT int _CFPosixSpawnFileActionsChdir(_CFPosixSpawnFileActionsRef file_actions, const char *path) {
+-  #if defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29)
++  #if defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29) || (defined(__ANDROID__) && __ANDROID_API__ < 34)
+   // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
+   //  - Amazon Linux 2 (EoL mid-2025)
+   return ENOSYS;
+diff --git a/swift-testing/cmake/modules/SwiftModuleInstallation.cmake b/swift-testing/cmake/modules/SwiftModuleInstallation.cmake
+index 1553725..d9f9e5b 100644
+--- a/swift-testing/cmake/modules/SwiftModuleInstallation.cmake
++++ b/swift-testing/cmake/modules/SwiftModuleInstallation.cmake
+@@ -75,6 +75,10 @@ function(_swift_testing_install_target module)
+     set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+     if(CMAKE_Swift_COMPILER_TARGET)
+       list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
++    else()
++      set(arg_list ${CMAKE_Swift_FLAGS})
++      separate_arguments(arg_list)
++      list(APPEND module_triple_command ${arg_list})
+     endif()
+     execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+     string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")

--- a/swift-ci/sdks/android/patches/swift-android-trunk-libdispatch.patch
+++ b/swift-ci/sdks/android/patches/swift-android-trunk-libdispatch.patch
@@ -1,0 +1,63 @@
+diff --git a/swift/test/Misc/verify-swift-feature-testing.test-sh b/swift/test/Misc/verify-swift-feature-testing.test-sh
+index 3f36fc979cb..8713ae8fea8 100755
+--- a/swift/test/Misc/verify-swift-feature-testing.test-sh
++++ b/swift/test/Misc/verify-swift-feature-testing.test-sh
+@@ -98,7 +98,6 @@ def find_matches(swift_src_root):
+     # `-enable-upcoming-feature` in the test directories.
+     output = subprocess.check_output(
+         [
+-            "git",
+             "grep",
+             "--extended-regexp",
+             "--recursive",
+diff --git a/swift/test/Reflection/conformance_descriptors.swift b/swift/test/Reflection/conformance_descriptors.swift
+index b114f764552..e1bd98c08f4 100644
+--- a/swift/test/Reflection/conformance_descriptors.swift
++++ b/swift/test/Reflection/conformance_descriptors.swift
+@@ -5,6 +5,7 @@
+ //
+ // Temporarily disable on AArch64 Linux (rdar://88451721)
+ // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
++// XFAIL: OS=linux-android
+ 
+ // rdar://100558042
+ // UNSUPPORTED: CPU=arm64e
+diff --git a/swift/test/Reflection/typeref_decoding.swift b/swift/test/Reflection/typeref_decoding.swift
+index e0a3b4465a3..c01af893eda 100644
+--- a/swift/test/Reflection/typeref_decoding.swift
++++ b/swift/test/Reflection/typeref_decoding.swift
+@@ -10,6 +10,7 @@
+ 
+ // FIXME: rdar://127796117
+ // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
++// XFAIL: OS=linux-android
+ 
+ // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+ // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/main.swift -emit-module -emit-executable %no-fixup-chains -module-name TypesToReflect -o %t/TypesToReflect
+diff --git a/swift-corelibs-libdispatch/cmake/modules/SwiftSupport.cmake b/swift-corelibs-libdispatch/cmake/modules/SwiftSupport.cmake
+index 3da519e..e2dd8ed 100644
+--- a/swift-corelibs-libdispatch/cmake/modules/SwiftSupport.cmake
++++ b/swift-corelibs-libdispatch/cmake/modules/SwiftSupport.cmake
+@@ -4,6 +4,10 @@ if(NOT dispatch_MODULE_TRIPLE)
+   set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+   if(CMAKE_Swift_COMPILER_TARGET)
+     list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
++  else()
++    set(arg_list ${CMAKE_Swift_FLAGS})
++    separate_arguments(arg_list)
++    list(APPEND module_triple_command ${arg_list})
+   endif()
+   execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+ 
+diff --git a/swift-corelibs-libdispatch/src/swift/CMakeLists.txt b/swift-corelibs-libdispatch/src/swift/CMakeLists.txt
+index 38bef37..d0ddf98 100644
+--- a/swift-corelibs-libdispatch/src/swift/CMakeLists.txt
++++ b/swift-corelibs-libdispatch/src/swift/CMakeLists.txt
+@@ -15,6 +15,7 @@ add_library(swiftDispatch
+   Source.swift
+   Time.swift
+   Wrapper.swift)
++set(CMAKE_SHARED_LINKER_FLAGS "")
+ target_compile_options(swiftDispatch PRIVATE
+   "SHELL:-Xcc -fblocks"
+   "SHELL:-Xcc -fmodule-map-file=${PROJECT_SOURCE_DIR}/dispatch/module.modulemap"

--- a/swift-ci/sdks/android/patches/swift-android.patch
+++ b/swift-ci/sdks/android/patches/swift-android.patch
@@ -59,47 +59,6 @@ index 7f290d16..95366592 100644
  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-diff --git a/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt b/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
-index 016bf294..5c42986a 100644
---- a/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
-+++ b/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
-@@ -162,6 +162,10 @@ if(NOT BUILD_SHARED_LIBS)
-         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
-     target_compile_options(Foundation PRIVATE
-         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
-+    if(${CMAKE_SYSTEM_NAME} STREQUAL Android)
-+      target_compile_options(Foundation PRIVATE
-+          "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend android-spawn>")
-+    endif()
- endif()
- 
- set_target_properties(Foundation PROPERTIES
-@@ -174,6 +174,12 @@
-     target_link_libraries(Foundation PUBLIC
-         swiftDispatch)
- endif()
-+  if(${CMAKE_SYSTEM_NAME} STREQUAL Android)
-+    target_link_libraries(Foundation PRIVATE android-spawn)
-+    list(GET CMAKE_FIND_ROOT_PATH 0 SPAWN_DIR)
-+    target_include_directories(Foundation PUBLIC ${SPAWN_DIR}/usr/include)
-+    target_link_directories(Foundation PUBLIC ${SPAWN_DIR}/usr/lib)
-+  endif()
- 
- if(LINKER_SUPPORTS_BUILD_ID)
-   target_link_options(Foundation PRIVATE "LINKER:--build-id=sha1")
-diff --git a/swift-corelibs-foundation/Sources/Foundation/Process.swift b/swift-corelibs-foundation/Sources/Foundation/Process.swift
-index 758dd1df..02970992 100644
---- a/swift-corelibs-foundation/Sources/Foundation/Process.swift
-+++ b/swift-corelibs-foundation/Sources/Foundation/Process.swift
-@@ -944,7 +944,7 @@ open class Process: NSObject, @unchecked Sendable {
-         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
- #endif
-         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
--#if os(Android)
-+#if os(Android)
-         guard var spawnAttrs else {
-             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno),
-                           userInfo: [NSURLErrorKey:self.executableURL!])
 diff --git a/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake b/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake
 index cbdfc2a..bb4121d 100644
 --- a/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake
@@ -127,22 +86,6 @@ index 1be9a4b..bd7b1bd 100644
  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-diff --git a/swift-testing/Sources/Testing/CMakeLists.txt b/swift-testing/Sources/Testing/CMakeLists.tx
-index e40cb1b..ff2f920 100644
---- a/swift-testing/Sources/Testing/CMakeLists.txt
-+++ b/swift-testing/Sources/Testing/CMakeLists.txt
-@@ -110,7 +110,10 @@ target_link_libraries(Testing PRIVATE
- if(NOT APPLE)
-   if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
-     target_link_libraries(Testing PUBLIC
--      dispatch)
-+      dispatch)
-+    list(GET CMAKE_FIND_ROOT_PATH 0 BT_DIR)
-+    target_include_directories(Testing PUBLIC ${BT_DIR}/usr/include)
-+    target_link_directories(Testing PUBLIC ${BT_DIR}/usr/lib)
-   endif()
-   target_link_libraries(Testing PUBLIC
-     Foundation)
 diff --git a/swift-testing/cmake/modules/TargetTriple.cmake b/swift-testing/cmake/modules/TargetTriple.cmake
 index e087cc4..02f3a95 100644
 --- a/swift-testing/cmake/modules/TargetTriple.cmake

--- a/swift-ci/sdks/android/patches/swift-android.patch
+++ b/swift-ci/sdks/android/patches/swift-android.patch
@@ -96,7 +96,7 @@ index 758dd1df..02970992 100644
  #endif
          try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
 -#if os(Android)
-+#if os(Windows)
++#if os(Android)
          guard var spawnAttrs else {
              throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno),
                            userInfo: [NSURLErrorKey:self.executableURL!])
@@ -136,7 +136,7 @@ index e40cb1b..ff2f920 100644
    if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
      target_link_libraries(Testing PUBLIC
 -      dispatch)
-+      dispatch android-execinfo)
++      dispatch)
 +    list(GET CMAKE_FIND_ROOT_PATH 0 BT_DIR)
 +    target_include_directories(Testing PUBLIC ${BT_DIR}/usr/include)
 +    target_link_directories(Testing PUBLIC ${BT_DIR}/usr/lib)

--- a/swift-ci/sdks/android/patches/swift-android.patch
+++ b/swift-ci/sdks/android/patches/swift-android.patch
@@ -1,0 +1,160 @@
+diff --git a/swift/utils/build-script-impl b/swift/utils/build-script-impl
+index 16e05052609..7ab8cebfab8 100755
+--- a/swift/utils/build-script-impl
++++ b/swift/utils/build-script-impl
+@@ -2622,6 +2622,7 @@ for host in "${ALL_HOSTS[@]}"; do
+                     echo "Cleaning the libdispatch build directory"
+                     call rm -rf "${LIBDISPATCH_BUILD_DIR}"
+                   fi
++                  call ln -sf "${SWIFT_BUILD_PATH}/lib/swift" "${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib"
+ 
+                   cmake_options=(
+                     -DENABLE_SWIFT=YES
+diff --git a/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py b/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py
+index 324d1a77eea..e88601a8701 100644
+--- a/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py
++++ b/swift/utils/swift_build_support/swift_build_support/products/swift_testing.py
+@@ -13,6 +13,9 @@
+ import os
+ 
+ from build_swift.build_swift.versions import Version
++from ..host_specific_configuration \
++    import HostSpecificConfiguration
++from ..targets import StdlibDeploymentTarget
+ 
+ from . import cmake_product
+ from . import product
+@@ -115,6 +117,22 @@ class SwiftTestingCMakeShim(cmake_product.CMakeProduct):
+         # FIXME: If we build macros for the builder, specify the path.
+         self.cmake_options.define('SwiftTesting_MACRO', 'NO')
+ 
++        if host_target.startswith('android') and self.is_cross_compile_target(host_target):
++            host_config = HostSpecificConfiguration(host_target, self.args)
++            self.cmake_options.extend(host_config.cmake_options)
++            flags = '-target %s-unknown-linux-android%s ' % (self.args.android_arch,
++                                                             self.args.android_api_level)
++
++            flags += '-resource-dir %s/lib/swift ' % (
++                     self.host_install_destdir(host_target) + self.args.install_prefix)
++
++            ndk_path = StdlibDeploymentTarget.get_target_for_name(host_target).platform.ndk_toolchain_path(self.args)
++            flags += '-sdk %s/sysroot ' % (ndk_path)
++            flags += '-tools-directory %s/bin' % (ndk_path)
++            self.cmake_options.define('CMAKE_Swift_FLAGS', flags)
++            self.cmake_options.define('CMAKE_CXX_COMPILER_WORKS', 'True')
++            self.cmake_options.define('CMAKE_FIND_ROOT_PATH', self.args.cross_compile_deps_path)
++
+         self.generate_toolchain_file_for_darwin_or_linux(
+             host_target, override_macos_deployment_version=override_deployment_version)
+         self.build_with_cmake([], self.args.build_variant, [],
+diff --git a/swift-corelibs-foundation/CMakeLists.txt b/swift-corelibs-foundation/CMakeLists.txt
+index 7f290d16..95366592 100644
+--- a/swift-corelibs-foundation/CMakeLists.txt
++++ b/swift-corelibs-foundation/CMakeLists.txt
+@@ -51,6 +51,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+     endif()
+ endif()
+ 
++set(CMAKE_SHARED_LINKER_FLAGS "")
+ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+diff --git a/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt b/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
+index 016bf294..5c42986a 100644
+--- a/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
++++ b/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
+@@ -162,6 +162,10 @@ if(NOT BUILD_SHARED_LIBS)
+         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
+     target_compile_options(Foundation PRIVATE
+         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
++    if(${CMAKE_SYSTEM_NAME} STREQUAL Android)
++      target_compile_options(Foundation PRIVATE
++          "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend android-spawn>")
++    endif()
+ endif()
+ 
+ set_target_properties(Foundation PROPERTIES
+@@ -174,6 +174,12 @@
+     target_link_libraries(Foundation PUBLIC
+         swiftDispatch)
+ endif()
++  if(${CMAKE_SYSTEM_NAME} STREQUAL Android)
++    target_link_libraries(Foundation PRIVATE android-spawn)
++    list(GET CMAKE_FIND_ROOT_PATH 0 SPAWN_DIR)
++    target_include_directories(Foundation PUBLIC ${SPAWN_DIR}/usr/include)
++    target_link_directories(Foundation PUBLIC ${SPAWN_DIR}/usr/lib)
++  endif()
+ 
+ if(LINKER_SUPPORTS_BUILD_ID)
+   target_link_options(Foundation PRIVATE "LINKER:--build-id=sha1")
+diff --git a/swift-corelibs-foundation/Sources/Foundation/Process.swift b/swift-corelibs-foundation/Sources/Foundation/Process.swift
+index 758dd1df..02970992 100644
+--- a/swift-corelibs-foundation/Sources/Foundation/Process.swift
++++ b/swift-corelibs-foundation/Sources/Foundation/Process.swift
+@@ -944,7 +944,7 @@ open class Process: NSObject, @unchecked Sendable {
+         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
+ #endif
+         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
+-#if os(Android)
++#if os(Windows)
+         guard var spawnAttrs else {
+             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno),
+                           userInfo: [NSURLErrorKey:self.executableURL!])
+diff --git a/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake b/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake
+index cbdfc2a..bb4121d 100644
+--- a/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake
++++ b/swift-foundation/cmake/modules/SwiftFoundationSwiftSupport.cmake
+@@ -37,6 +37,10 @@ function(_swift_foundation_install_target module)
+     set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+     if(CMAKE_Swift_COMPILER_TARGET)
+       list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
++    else()
++      set(arg_list ${CMAKE_Swift_FLAGS})
++      separate_arguments(arg_list)
++      list(APPEND module_triple_command ${arg_list})
+     endif()
+     execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+     string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+diff --git a/swift-testing/CMakeLists.txt b/swift-testing/CMakeLists.txt
+index 1be9a4b..bd7b1bd 100644
+--- a/swift-testing/CMakeLists.txt
++++ b/swift-testing/CMakeLists.txt
+@@ -28,6 +28,7 @@ list(APPEND CMAKE_MODULE_PATH
+   ${PROJECT_SOURCE_DIR}/cmake/modules
+   ${PROJECT_SOURCE_DIR}/cmake/modules/shared)
+ 
++set(CMAKE_SHARED_LINKER_FLAGS "")
+ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+diff --git a/swift-testing/Sources/Testing/CMakeLists.txt b/swift-testing/Sources/Testing/CMakeLists.tx
+index e40cb1b..ff2f920 100644
+--- a/swift-testing/Sources/Testing/CMakeLists.txt
++++ b/swift-testing/Sources/Testing/CMakeLists.txt
+@@ -110,7 +110,10 @@ target_link_libraries(Testing PRIVATE
+ if(NOT APPLE)
+   if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+     target_link_libraries(Testing PUBLIC
+-      dispatch)
++      dispatch android-execinfo)
++    list(GET CMAKE_FIND_ROOT_PATH 0 BT_DIR)
++    target_include_directories(Testing PUBLIC ${BT_DIR}/usr/include)
++    target_link_directories(Testing PUBLIC ${BT_DIR}/usr/lib)
+   endif()
+   target_link_libraries(Testing PUBLIC
+     Foundation)
+diff --git a/swift-testing/cmake/modules/TargetTriple.cmake b/swift-testing/cmake/modules/TargetTriple.cmake
+index e087cc4..02f3a95 100644
+--- a/swift-testing/cmake/modules/TargetTriple.cmake
++++ b/swift-testing/cmake/modules/TargetTriple.cmake
+@@ -10,6 +10,10 @@
+ set(SWT_TARGET_INFO_COMMAND "${CMAKE_Swift_COMPILER}" -print-target-info)
+ if(CMAKE_Swift_COMPILER_TARGET)
+   list(APPEND SWT_TARGET_INFO_COMMAND -target ${CMAKE_Swift_COMPILER_TARGET})
++else()
++      set(arg_list ${CMAKE_Swift_FLAGS})
++      separate_arguments(arg_list)
++      list(APPEND SWT_TARGET_INFO_COMMAND ${arg_list})
+ endif()
+ execute_process(COMMAND ${SWT_TARGET_INFO_COMMAND} OUTPUT_VARIABLE SWT_TARGET_INFO_JSON)
+ string(JSON SWT_TARGET_TRIPLE GET "${SWT_TARGET_INFO_JSON}" "target" "unversionedTriple")

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -50,7 +50,7 @@ function groupend {
 
 function usage {
     cat <<EOF
-usage: build.sh --source-dir <path> --products-dir <path> --ndk-home <path> --host-toolchain <path>
+usage: build.sh --source-dir <path> --products-dir <path> --ndk-home <path>
                 [--name <sdk-name>] [--version <version>] [--build-dir <path>]
                 [--archs <arch>[,<arch> ...]]
 
@@ -158,7 +158,7 @@ done
 # Change the commas for spaces
 archs="${archs//,/ }"
 
-if [[ -z "$source_dir" || -z "$products_dir" || -z "$ndk_home" || -z "$host_toolchain" ]]; then
+if [[ -z "$source_dir" || -z "$products_dir" || -z "$ndk_home" ]]; then
     usage
     exit 1
 fi
@@ -237,8 +237,10 @@ export ANDROID_NDK_HOME=$ndk_home
 export ANDROID_NDK=$ndk_home
 
 echo "Swift found at ${swift_dir}"
-echo "Host toolchain found at ${host_toolchain}"
-${host_toolchain}/bin/swift --version
+if [[ ! -z "${host_toolchain}" ]]; then
+    echo "Host toolchain found at ${host_toolchain}"
+    ${host_toolchain}/bin/swift --version
+fi
 echo "Android NDK found at ${ndk_home}"
 ${ndk_installation}/bin/clang --version
 echo "Building for ${archs}"

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -446,6 +446,7 @@ for arch in $archs; do
             ${build_cmark} \
             ${local_build} \
             --host-test \
+            --skip-test-linux \
             --build-swift-static-stdlib \
             --install-swift \
             --install-libdispatch \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -385,6 +385,7 @@ for arch in $archs; do
             1|true|yes|YES)
                 build_cmark=""
                 local_build=""
+                build_llvm="1"
                 build_swift_tools="1"
                 validation_test="1"
                 native_swift_tools_path=""
@@ -393,6 +394,7 @@ for arch in $archs; do
             *)
                 build_cmark="--skip-build-cmark"
                 local_build="--skip-local-build"
+                build_llvm="0"
                 build_swift_tools="0"
                 validation_test="0"
                 native_swift_tools_path="--native-swift-tools-path=$host_toolchain/bin"
@@ -415,7 +417,7 @@ for arch in $archs; do
             --cross-compile-hosts=android-$arch \
             --cross-compile-deps-path=$sdk_root \
             --install-destdir=$sdk_root \
-            --build-llvm=0 \
+            --build-llvm=$build_llvm \
             --build-swift-tools=$build_swift_tools \
             ${native_swift_tools_path} \
             ${native_clang_tools_path} \
@@ -428,6 +430,7 @@ for arch in $archs; do
             --xctest --install-xctest \
             --swift-testing --install-swift-testing \
             --cross-compile-build-swift-tools=0 \
+            --llvm-ninja-targets-for-cross-compile-hosts=help \
             --cross-compile-append-host-target-to-destdir=False \
             --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -265,11 +265,31 @@ function run() {
 
 for arch in $archs; do
     case $arch in
-        armv7) target_host="arm-linux-androideabi"; compiler_target_host="armv7a-linux-androideabi$android_api"; android_abi="armeabi-v7a" ;;
-        aarch64) target_host="aarch64-linux-android"; compiler_target_host="$target_host$android_api"; android_abi="arm64-v8a" ;;
-        x86_64) target_host="x86_64-linux-android"; compiler_target_host="$target_host$android_api"; android_abi="x86_64" ;;
-        x86) target_host="x86-linux-android"; compiler_target_host="$target_host$android_api"; android_abi="x86" ;;
-        *) echo "Unknown architecture '$1'"; usage; exit 0 ;;
+        armv7)
+            target_host="arm-linux-androideabi"
+            compiler_target_host="armv7a-linux-androideabi$android_api"
+            android_abi="armeabi-v7a"
+            ;;
+        aarch64)
+            target_host="aarch64-linux-android"
+            compiler_target_host="$target_host$android_api"
+            android_abi="arm64-v8a"
+            ;;
+        x86_64)
+            target_host="x86_64-linux-android"
+            compiler_target_host="$target_host$android_api"
+            android_abi="x86_64"
+            ;;
+        x86)
+            target_host="x86-linux-android"
+            compiler_target_host="$target_host$android_api"
+            android_abi="x86"
+            ;;
+        *)
+            echo "Unknown architecture '$1'"
+            usage
+            exit 0
+            ;;
     esac
 
     sdk_root=${build_dir}/sdk_root/${arch}

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -445,6 +445,7 @@ for arch in $archs; do
             ${native_clang_tools_path} \
             ${build_cmark} \
             ${local_build} \
+            --host-test \
             --build-swift-static-stdlib \
             --install-swift \
             --install-libdispatch \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -385,7 +385,6 @@ for arch in $archs; do
             1|true|yes|YES)
                 build_cmark=""
                 local_build=""
-                build_llvm="1"
                 build_swift_tools="1"
                 validation_test="1"
                 native_swift_tools_path=""
@@ -394,7 +393,6 @@ for arch in $archs; do
             *)
                 build_cmark="--skip-build-cmark"
                 local_build="--skip-local-build"
-                build_llvm="0"
                 build_swift_tools="0"
                 validation_test="0"
                 native_swift_tools_path="--native-swift-tools-path=$host_toolchain/bin"
@@ -417,7 +415,7 @@ for arch in $archs; do
             --cross-compile-hosts=android-$arch \
             --cross-compile-deps-path=$sdk_root \
             --install-destdir=$sdk_root \
-            --build-llvm=$build_llvm \
+            --build-llvm=0 \
             --build-swift-tools=$build_swift_tools \
             ${native_swift_tools_path} \
             ${native_clang_tools_path} \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -529,7 +529,8 @@ for arch in $archs; do
             arch_triple="arm-linux-androideabi"
         fi
 
-        rm -r lib/swift{,_static}/{clang,linux}
+        # need force rm in case linux is not present (when not running tests)
+        rm -rf lib/swift{,_static}/{clang,linux}
         mv lib/swift lib/swift-$arch
         ln -s ../swift/clang lib/swift-$arch/clang
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -447,7 +447,7 @@ for arch in $archs; do
             ${local_build} \
             --host-test \
             --skip-test-linux \
-            --skip-test-xctest \
+            --skip-test-xctest --skip-test-foundation \
             --build-swift-static-stdlib \
             --install-swift \
             --install-libdispatch \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -114,7 +114,7 @@ declare_package boringssl "boringssl" "OpenSSL AND ISC AND MIT" \
 # Parse command line arguments
 android_sdk_version=0.1
 sdk_name=
-archs=aarch64,armv7,x86_64
+archs=armv7,aarch64,x86_64
 android_api=28
 build_type=Release
 parallel_jobs=$(($(nproc --all) + 2))

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -447,6 +447,7 @@ for arch in $archs; do
             ${local_build} \
             --host-test \
             --skip-test-linux \
+            --skip-test-xctest \
             --build-swift-static-stdlib \
             --install-swift \
             --install-libdispatch \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -453,12 +453,11 @@ for arch in $archs; do
             --install-libdispatch \
             --install-foundation \
             --xctest --install-xctest \
-            --swift-testing --install-swift-testing \
             --cross-compile-build-swift-tools=0 \
             --llvm-ninja-targets-for-cross-compile-hosts=help \
-            --cross-compile-append-host-target-to-destdir=False \
-            --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
-
+            --cross-compile-append-host-target-to-destdir=False 
+            # --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
+        # --swift-testing --install-swift-testing \
         # need to remove symlink that gets created in the NDK to the previous arch's build
         # or else we get errors like:
         # error: could not find module '_Builtin_float' for target 'x86_64-unknown-linux-android'; found: aarch64-unknown-linux-android, at: /home/runner/work/_temp/swift-android-sdk/ndk/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift/android/_Builtin_float.swiftmodule

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -114,7 +114,7 @@ declare_package boringssl "boringssl" "OpenSSL AND ISC AND MIT" \
 # Parse command line arguments
 android_sdk_version=0.1
 sdk_name=
-archs=armv7,aarch64,x86_64
+archs=armv7,x86_64
 android_api=28
 build_type=Release
 parallel_jobs=$(($(nproc --all) + 2))

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -675,7 +675,7 @@ cat > swift-toolset.json <<EOF
 {
   "cCompiler": { "extraCLIOptions": ["-fPIC"] },
   "swiftCompiler": { "extraCLIOptions": ["-Xclang-linker", "-fuse-ld=lld"] },
-  "linker": { "extraCLIOptions": ["-z,max-page-size=16384"] },
+  "linker": { "extraCLIOptions": ["-z", "max-page-size=16384"] },
   "schemaVersion": "1.0"
 }
 EOF

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -114,7 +114,7 @@ declare_package boringssl "boringssl" "OpenSSL AND ISC AND MIT" \
 # Parse command line arguments
 android_sdk_version=0.1
 sdk_name=
-archs=armv7,aarch64,x86_64
+archs=aarch64,armv7,x86_64
 android_api=28
 build_type=Release
 parallel_jobs=$(($(nproc --all) + 2))
@@ -449,16 +449,16 @@ for arch in $archs; do
             --skip-test-linux \
             --skip-test-xctest --skip-test-foundation \
             --build-swift-static-stdlib \
-            --swift-install-components='clang-resource-dir-symlink;license;stdlib;sdk-overlay' \
+            --swift-install-components='compiler;clang-resource-dir-symlink;license;stdlib;sdk-overlay' \
             --install-swift \
             --install-libdispatch \
             --install-foundation \
             --xctest --install-xctest \
+            --swift-testing --install-swift-testing \
             --cross-compile-build-swift-tools=0 \
             --llvm-ninja-targets-for-cross-compile-hosts=help \
             --cross-compile-append-host-target-to-destdir=False 
             # --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
-        # --swift-testing --install-swift-testing \
         # need to remove symlink that gets created in the NDK to the previous arch's build
         # or else we get errors like:
         # error: could not find module '_Builtin_float' for target 'x86_64-unknown-linux-android'; found: aarch64-unknown-linux-android, at: /home/runner/work/_temp/swift-android-sdk/ndk/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift/android/_Builtin_float.swiftmodule
@@ -530,7 +530,8 @@ for arch in $archs; do
         fi
 
         # need force rm in case linux is not present (when not running tests)
-        rm -rf lib/swift{,_static}/{clang,linux}
+        rm -rf lib/swift{,_static}/{FrameworkABIBaseline,_InternalSwiftScan,_InternalSwiftStaticMirror,clang,embedded,host,linux,migrator}
+        rm -rf lib/lib*.so
         mv lib/swift lib/swift-$arch
         ln -s ../swift/clang lib/swift-$arch/clang
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -429,6 +429,7 @@ for arch in $archs; do
             --install-foundation \
             --xctest --install-xctest \
             --swift-testing --install-swift-testing \
+            --cross-compile-build-swift-tools=0 \
             --cross-compile-append-host-target-to-destdir=False \
             --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -424,8 +424,8 @@ for arch in $archs; do
                 ;;
         esac
 
-        # use an out-of-tree build folder, otherwise subsequent arch builds have conflicts
-        export SWIFT_BUILD_ROOT=${build_dir}/$arch/swift-project
+        # use an out-of-tree build folder
+        export SWIFT_BUILD_ROOT=${build_dir}/swift-project
 
         ./swift/utils/build-script \
             $build_type_flag \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -114,7 +114,7 @@ declare_package boringssl "boringssl" "OpenSSL AND ISC AND MIT" \
 # Parse command line arguments
 android_sdk_version=0.1
 sdk_name=
-archs=armv7,x86_64
+archs=armv7,aarch64,x86_64
 android_api=28
 build_type=Release
 parallel_jobs=$(($(nproc --all) + 2))
@@ -449,6 +449,7 @@ for arch in $archs; do
             --skip-test-linux \
             --skip-test-xctest --skip-test-foundation \
             --build-swift-static-stdlib \
+            --swift-install-components='clang-resource-dir-symlink;license;stdlib;sdk-overlay' \
             --install-swift \
             --install-libdispatch \
             --install-foundation \
@@ -528,7 +529,7 @@ for arch in $archs; do
             arch_triple="arm-linux-androideabi"
         fi
 
-        rm -r lib/swift{,_static}/clang
+        rm -r lib/swift{,_static}/{clang,linux}
         mv lib/swift lib/swift-$arch
         ln -s ../swift/clang lib/swift-$arch/clang
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -385,19 +385,14 @@ for arch in $archs; do
             $build_type_flag \
             --reconfigure \
             --no-assertions \
+            --validation-test=1 \
             --android \
             --android-ndk=$ndk_home \
             --android-arch=$arch \
             --android-api-level=$android_api \
-            --native-swift-tools-path=$host_toolchain/bin \
-            --native-clang-tools-path=$host_toolchain/bin \
             --cross-compile-hosts=android-$arch \
             --cross-compile-deps-path=$sdk_root \
             --install-destdir=$sdk_root \
-            --build-llvm=0 \
-            --build-swift-tools=0 \
-            --skip-build-cmark \
-            --skip-local-build \
             --build-swift-static-stdlib \
             --install-swift \
             --install-libdispatch \

--- a/swift-ci/sdks/android/scripts/fetch-source.sh
+++ b/swift-ci/sdks/android/scripts/fetch-source.sh
@@ -195,7 +195,7 @@ git checkout ${BORINGSSL_VERSION}
 popd >/dev/null 2>&1
 groupend
 
-# Fetch BoringSSL
+# Fetch Patches
 groupstart "Fetching Patches"
 [[ -d swift-android-patches ]] || git clone https://github.com/swift-android-sdk/swift-android-sdk swift-android-patches
 pushd swift-android-patches >/dev/null 2>&1

--- a/swift-ci/sdks/android/scripts/fetch-source.sh
+++ b/swift-ci/sdks/android/scripts/fetch-source.sh
@@ -160,7 +160,9 @@ groupend
 
 # Fetch yams (needed for Swift 6.1.1)
 groupstart "Fetching yams"
+pushd swift-project >/dev/null
 [[ -d yams ]] || git clone ${github}jpsim/Yams.git yams
+popd >/dev/null
 groupend
 
 # Fetch libxml2

--- a/swift-ci/sdks/android/scripts/fetch-source.sh
+++ b/swift-ci/sdks/android/scripts/fetch-source.sh
@@ -165,7 +165,7 @@ groupend
 groupstart "Fetching yams"
 pushd swift-project >/dev/null
 [[ -d yams ]] || git clone ${github}jpsim/Yams.git yams
-pushd libxml2 >/dev/null 2>&1
+pushd yams >/dev/null 2>&1
 git checkout ${YAMS_VERSION}
 popd >/dev/null 2>&1
 popd >/dev/null

--- a/swift-ci/sdks/android/scripts/fetch-source.sh
+++ b/swift-ci/sdks/android/scripts/fetch-source.sh
@@ -89,6 +89,9 @@ fi
 if [[ -z "${BORINGSSL_VERSION}" ]]; then
     BORINGSSL_VERSION=fips-20220613
 fi
+if [[ -z "${YAMS_VERSION}" ]]; then
+    YAMS_VERSION=5.0.6
+fi
 if [[ -z "${SWIFT_ANDROID_PATCHES_VERSION}" ]]; then
     SWIFT_ANDROID_PATCHES_VERSION=main
 fi
@@ -158,10 +161,13 @@ fi
 popd >/dev/null
 groupend
 
-# Fetch yams (needed for Swift 6.1.1)
+# Fetch yams (needed for Swift 6.1.x)
 groupstart "Fetching yams"
 pushd swift-project >/dev/null
 [[ -d yams ]] || git clone ${github}jpsim/Yams.git yams
+pushd libxml2 >/dev/null 2>&1
+git checkout ${YAMS_VERSION}
+popd >/dev/null 2>&1
 popd >/dev/null
 groupend
 

--- a/swift-ci/sdks/android/scripts/fetch-source.sh
+++ b/swift-ci/sdks/android/scripts/fetch-source.sh
@@ -92,9 +92,6 @@ fi
 if [[ -z "${YAMS_VERSION}" ]]; then
     YAMS_VERSION=5.0.6
 fi
-if [[ -z "${SWIFT_ANDROID_PATCHES_VERSION}" ]]; then
-    SWIFT_ANDROID_PATCHES_VERSION=main
-fi
 
 clone_with_ssh=false
 while [ "$#" -gt 0 ]; do
@@ -195,10 +192,3 @@ git checkout ${BORINGSSL_VERSION}
 popd >/dev/null 2>&1
 groupend
 
-# Fetch Patches
-groupstart "Fetching Patches"
-[[ -d swift-android-patches ]] || git clone https://github.com/swift-android-sdk/swift-android-sdk swift-android-patches
-pushd swift-android-patches >/dev/null 2>&1
-git checkout ${SWIFT_ANDROID_PATCHES_VERSION}
-popd >/dev/null 2>&1
-groupend

--- a/swift-ci/sdks/android/scripts/fetch-source.sh
+++ b/swift-ci/sdks/android/scripts/fetch-source.sh
@@ -158,6 +158,11 @@ fi
 popd >/dev/null
 groupend
 
+# Fetch yams (needed for Swift 6.1.1)
+groupstart "Fetching yams"
+[[ -d yams ]] || git clone ${github}jpsim/Yams.git yams
+groupend
+
 # Fetch libxml2
 groupstart "Fetching libxml2"
 [[ -d libxml2 ]] || git clone ${github}GNOME/libxml2.git

--- a/swift-ci/sdks/android/scripts/toolchain-vars.sh
+++ b/swift-ci/sdks/android/scripts/toolchain-vars.sh
@@ -35,5 +35,8 @@ case "${BUILD_SCHEME}" in
 esac
 
 SWIFT_BASE=$SWIFT_TAG-$HOST_OS
-export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/$SWIFT_TAG/$SWIFT_BASE.tar.gz"
-
+if [[ "${BUILD_SCHEME}" == "development" ]]; then
+  export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/swift-DEVELOPMENT-SNAPSHOT-2025-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2025-06-12-a-$HOST_OS.tar.gz"
+else
+  export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/$SWIFT_TAG/$SWIFT_BASE.tar.gz"
+fi

--- a/swift-ci/sdks/android/scripts/toolchain-vars.sh
+++ b/swift-ci/sdks/android/scripts/toolchain-vars.sh
@@ -13,14 +13,16 @@
 # obtain the latest toolchain for building.
 
 OS=$(echo $HOST_OS | tr -d '.')
+# e.g., "swift-6.1-RELEASE"
+# there is no latest-build.yml for releases, so we need to get it from the API
+export RELEASE_TAG=$(curl -fsSL https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag')
+# e.g., "swift-6.1-release"
+export RELEASE_BRANCH=$(echo "${SWIFT_TAG}" | tr '[A-Z]' '[a-z]')
 
 case "${BUILD_SCHEME}" in
     release)
-        # e.g., "swift-6.1-RELEASE"
-        # there is no latest-build.yml for releases, so we need to get it from the API
-        export SWIFT_TAG=$(curl -fsSL https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag')
-        # e.g., "swift-6.1-release"
-        export SWIFT_BRANCH=$(echo "${SWIFT_TAG}" | tr '[A-Z]' '[a-z]')
+        export SWIFT_TAG=$RELEASE_TAG
+        export SWIFT_BRANCH=$RELEASE_BRANCH
         ;;
     development|swift-*-branch)
         # e.g., swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-15-a
@@ -35,8 +37,11 @@ case "${BUILD_SCHEME}" in
 esac
 
 SWIFT_BASE=$SWIFT_TAG-$HOST_OS
-if [[ "${BUILD_SCHEME}" == "development" ]]; then
-  export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/swift-DEVELOPMENT-SNAPSHOT-2025-06-12-a/swift-DEVELOPMENT-SNAPSHOT-2025-06-12-a-$HOST_OS.tar.gz"
-else
-  export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/$SWIFT_TAG/$SWIFT_BASE.tar.gz"
-fi
+case $BUILD_COMPILER in
+    1|true|yes|YES)
+        export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$RELEASE_BRANCH/$OS/$RELEASE_TAG/$RELEASE_TAG-$HOST_OS.tar.gz"
+        ;;
+    *)
+        export SWIFT_TOOLCHAIN_URL="https://download.swift.org/$SWIFT_BRANCH/$OS/$SWIFT_TAG/$SWIFT_BASE.tar.gz"
+        ;;
+esac

--- a/swift-ci/sdks/android/scripts/toolchain-vars.sh
+++ b/swift-ci/sdks/android/scripts/toolchain-vars.sh
@@ -15,9 +15,9 @@
 OS=$(echo $HOST_OS | tr -d '.')
 # e.g., "swift-6.1-RELEASE"
 # there is no latest-build.yml for releases, so we need to get it from the API
-export RELEASE_TAG=$(curl -fsSL https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag')
+RELEASE_TAG=$(curl -fsSL https://www.swift.org/api/v1/install/releases.json | jq -r '.[-1].tag')
 # e.g., "swift-6.1-release"
-export RELEASE_BRANCH=$(echo "${SWIFT_TAG}" | tr '[A-Z]' '[a-z]')
+RELEASE_BRANCH=$(echo "${RELEASE_TAG}" | tr '[A-Z]' '[a-z]')
 
 case "${BUILD_SCHEME}" in
     release)


### PR DESCRIPTION
> Please see if you can get your Docker build to run the compiler validation suite for Android too. That means you can stop downloading the latest Swift toolchain release and snapshots, as we will be building the compiler for linux from source instead, and you can remove these flags
```
--native-swift-tools-path=$host_toolchain/bin \
            --native-clang-tools-path=$host_toolchain/bin \
            --build-llvm=0 \
            --build-swift-tools=0 \
            --skip-build-cmark \
            --skip-local-build \
``` 
> to make sure the native compiler is built and [add the testing flags](https://github.com/swiftlang/swift/blob/main/docs/Android.md#running-the-swift-test-suite-hosted-on-an-android-device). It should mostly work just by changing flags, but will likely require [some light patching like this](https://github.com/swiftlang/swift/pull/38441), to avoid unnecessary extra work.