### PR TITLE
Wildcard the clang version link in the post-install script in order to accomodate NDK 27 and 28

### DIFF
--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -611,7 +611,8 @@ else
 fi
 
 # link the NDK's clang resource directory
-ln -sf ${ndk_prebuilt}/*/lib/clang/18 ${swift_resources}/usr/lib/swift/clang
+# e.g., ~/Library/Android/sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/18 or /opt/homebrew/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/19
+ln -sf ${ndk_prebuilt}/*/lib/clang/* ${swift_resources}/usr/lib/swift/clang
 
 # copy each architecture's swiftrt.o into the sysroot,
 # working around https://github.com/swiftlang/swift/pull/79621


### PR DESCRIPTION
This is needed because NDK 27 uses Clang 18 and NDK 28 uses 19. E.g., we want to be able to handle both these `ANDROID_NDK_HOME` locations:

```
~/Library/Android/sdk/ndk/27.0.12077973/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/18
/opt/homebrew/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/19
```